### PR TITLE
Use userEvent in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "classnames": "^2.5.1",
-    "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '../../../test/testUtils';
+import { render, screen } from '../../../test/testUtils';
 import Button, { ButtonProps } from './Button';
 
 const onClickSpy = jest.fn();
@@ -7,6 +7,7 @@ const defaultProps: ButtonProps = {
   onClick: onClickSpy,
   children: 'click me',
 };
+
 const setup = (props: Partial<ButtonProps> = {}) => {
   const combinedProps = { ...defaultProps, ...props };
 
@@ -20,133 +21,139 @@ describe('The Button component', () => {
 
   describe('when binding the button to a form', () => {
     it('passes the form property to the form attribute on the button', () => {
-      const { getByRole } = setup({ form: 'submit-this-form' });
+      setup({
+        form: 'submit-this-form',
+      });
 
-      expect(getByRole('button').getAttribute('form')).toBe('submit-this-form');
+      expect(screen.getByRole('button').getAttribute('form')).toBe(
+        'submit-this-form',
+      );
     });
   });
 
   describe('when passing addtional classes to the form', () => {
     it('passes the class property to the class attribute on the button', () => {
-      const { getByRole } = setup({ className: 'additional-classes' });
+      setup({
+        className: 'additional-classes',
+      });
 
-      expect(getByRole('button')).toHaveClass('additional-classes');
+      expect(screen.getByRole('button')).toHaveClass('additional-classes');
     });
   });
 
   describe('when clicking the button', () => {
-    it('invokes the given click handler', () => {
-      const { getByRole } = setup();
+    it('invokes the given click handler', async () => {
+      const { user } = setup();
 
-      fireEvent.click(getByRole('button'));
+      await user.click(screen.getByRole('button'));
 
       expect(onClickSpy).toHaveBeenCalled();
     });
   });
 
   describe('when the button is disabled', () => {
-    it('does not invoke the given click handler when the button is clicked', () => {
-      const { getByRole } = setup({
+    it('does not invoke the given click handler when the button is clicked', async () => {
+      const { user } = setup({
         disabled: true,
       });
 
-      fireEvent.click(getByRole('button'));
+      await user.click(screen.getByRole('button'));
 
       expect(onClickSpy).not.toHaveBeenCalled();
     });
 
     it('sets the aria-disabled attribute to true', () => {
-      const { getByRole } = setup({
+      setup({
         disabled: true,
       });
 
-      expect(getByRole('button').getAttribute('aria-disabled')).toBe('true');
+      expect(screen.getByRole('button').getAttribute('aria-disabled')).toBe('true');
     });
   });
 
   describe('when the button is loading', () => {
-    it('does not invoke the given click handler when the button is clicked', () => {
-      const { getByRole } = setup({
+    it('does not invoke the given click handler when the button is clicked', async () => {
+      const { user } = setup({
         loading: true,
       });
 
-      fireEvent.click(getByRole('button'));
+      await user.click(screen.getByRole('button'));
 
       expect(onClickSpy).not.toHaveBeenCalled();
     });
 
     it('sets the aria-busy attribute to true', () => {
-      const { getByRole } = setup({
+      setup({
         loading: true,
       });
 
-      expect(getByRole('button').getAttribute('aria-busy')).toBe('true');
+      expect(screen.getByRole('button').getAttribute('aria-busy')).toBe('true');
     });
 
     it('sets the aria-disabled attribute to true', () => {
-      const { getByRole } = setup({
+      setup({
         loading: true,
       });
 
-      expect(getByRole('button').getAttribute('aria-disabled')).toBe('true');
+      expect(screen.getByRole('button').getAttribute('aria-disabled')).toBe('true');
     });
   });
 
   describe('when the button is displayed as the ghost variation', () => {
     it('displays the background as transparent', () => {
-      const { getByRole } = setup({
+      setup({
         ghost: true,
       });
 
-      expect(getByRole('button')).toHaveClass('bg-transparent');
+      expect(screen.getByRole('button')).toHaveClass('bg-transparent');
     });
 
     it('displays the border as white for primary buttons', () => {
-      const { getByRole } = setup({
+      setup({
         ghost: true,
         kind: 'primary',
       });
 
-      expect(getByRole('button')).toHaveClass('border-neutral-100');
+      expect(screen.getByRole('button')).toHaveClass('border-neutral-100');
     });
 
     it('displays the border as white on hover for secondary disabled buttons', () => {
-      const { getByRole } = setup({
+      setup({
         ghost: true,
         kind: 'secondary',
       });
 
-      expect(getByRole('button')).toHaveClass('hover:border-neutral-100');
+      expect(screen.getByRole('button')).toHaveClass('hover:border-neutral-100');
     });
 
     it('displays the border as white for secondary disabled buttons', () => {
-      const { getByRole } = setup({
+      setup({
         disabled: true,
         ghost: true,
         kind: 'secondary',
       });
 
-      expect(getByRole('button')).toHaveClass('border-neutral-100');
+      expect(screen.getByRole('button')).toHaveClass('border-neutral-100');
     });
   });
 
   describe('when the button is displayed as the warn variation', () => {
     it('displays the background as red for primary buttons', () => {
-      const { getByRole } = setup({
+      setup({
         warn: true,
         kind: 'primary',
       });
 
-      expect(getByRole('button')).toHaveClass('bg-red-400');
+      expect(screen.getByRole('button')).toHaveClass('bg-red-400');
     });
 
     it('displays the text as red for primary buttons', () => {
-      const { getByRole } = setup({
+      setup({
         warn: true,
         kind: 'secondary',
       });
 
-      expect(getByRole('button')).toHaveClass('text-red-400');
+      expect(screen.getByRole('button')).toHaveClass('text-red-400');
     });
   });
 });

--- a/src/components/Loader/Loader.test.tsx
+++ b/src/components/Loader/Loader.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '../../../test/testUtils';
+import { render, screen } from '../../../test/testUtils';
 import Loader, { LoaderProps } from './Loader';
 import { LOADER_COLORS, LOADER_SIZES } from './constants';
 
@@ -14,43 +14,45 @@ const setup = (props: Partial<LoaderProps> = {}) => {
 
 describe('The Loader component', () => {
   it('displays the loader as an accessible alert', () => {
-    const { getByRole } = setup();
+    setup();
 
-    expect(getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toBeInTheDocument();
   });
 
   it('displays the loader at the correct size', () => {
-    const { getByRole } = setup({ size: 'large' });
+    setup({
+      size: 'large',
+    });
 
-    expect(getByRole('alert').firstElementChild!.getAttribute('height')).toBe(
+    expect(screen.getByRole('alert').firstElementChild!.getAttribute('height')).toBe(
       `${LOADER_SIZES.large}`,
     );
-    expect(getByRole('alert').firstElementChild!.getAttribute('width')).toBe(
+    expect(screen.getByRole('alert').firstElementChild!.getAttribute('width')).toBe(
       `${LOADER_SIZES.large}`,
     );
   });
 
   it('displays the loader in the correct color', () => {
-    const { getByRole } = setup({ color: 'secondary' });
+    setup({ color: 'secondary' });
 
-    expect(getByRole('alert').firstElementChild!.classList).toContain(
+    expect(screen.getByRole('alert').firstElementChild!.classList).toContain(
       LOADER_COLORS.secondary,
     );
   });
 
   it('adds a test id', () => {
-    const { getByRole } = setup();
+    setup();
 
-    expect(getByRole('alert').getAttribute('data-testid')).toBe(
+    expect(screen.getByRole('alert').getAttribute('data-testid')).toBe(
       'crate-loading-spinner',
     );
   });
 
   it('displays the message if a message is passed', () => {
-    const { getByText } = setup({
+    setup({
       message: <div>Your resource is loading</div>,
     });
 
-    expect(getByText('Your resource is loading')).toBeInTheDocument();
+    expect(screen.getByText('Your resource is loading')).toBeInTheDocument();
   });
 });

--- a/src/components/Text/Text.test.tsx
+++ b/src/components/Text/Text.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '../../../test/testUtils';
+import { render, screen } from '../../../test/testUtils';
 import Text, { TextProps } from './Text';
 
 const defaultProps: TextProps = {
@@ -13,66 +13,70 @@ const setup = (props: Partial<TextProps> = {}) => {
 
 describe('The Text component', () => {
   it('displays the text passed as value', () => {
-    const { getByText } = setup();
+    setup();
 
-    expect(getByText('the Text value')).toBeInTheDocument();
+    expect(screen.getByText('the Text value')).toBeInTheDocument();
   });
 
   it('displays the text as a div element by default', () => {
-    const { getByText } = setup({
+    setup({
       children: 'this is a div element',
     });
 
-    expect(getByText('this is a div element').nodeName).toBe('DIV');
+    expect(screen.getByText('this is a div element').nodeName).toBe('DIV');
   });
 
   it('supports displaying the text as a P element', () => {
-    const { getByText } = setup({
+    setup({
       displayAs: 'p',
       children: 'this is a p element',
     });
 
-    expect(getByText('this is a p element').nodeName).toBe('P');
+    expect(screen.getByText('this is a p element').nodeName).toBe('P');
   });
 
   it('supports displaying the text as a span element', () => {
-    const { getByText } = setup({
+    setup({
       displayAs: 'span',
       children: 'this is a span element',
     });
 
-    expect(getByText('this is a span element').nodeName).toBe('SPAN');
+    expect(screen.getByText('this is a span element').nodeName).toBe('SPAN');
   });
 
   it('supports displaying the text in a lighter font weight', () => {
-    const { getByText } = setup({
+    setup({
       children: 'this is pale text',
       pale: true,
     });
 
     expect(
-      getByText('this is pale text').classList.contains('text-neutral-500'),
+      screen.getByText('this is pale text').classList.contains('text-neutral-500'),
     ).toBe(true);
   });
 
   it('supports truncating the text', () => {
-    const { getByText } = setup({
+    setup({
       children: 'this text is truncated',
       truncate: true,
     });
 
-    expect(getByText('this text is truncated').classList.contains('truncate')).toBe(
-      true,
-    );
+    expect(
+      screen.getByText('this text is truncated').classList.contains('truncate'),
+    ).toBe(true);
   });
 
   it('adds any additional classes to the existing display classes', () => {
-    const { getByText } = setup({
+    setup({
       className: 'foo bar',
       children: 'with custom classes',
     });
 
-    expect(getByText('with custom classes').classList.contains('foo')).toBe(true);
-    expect(getByText('with custom classes').classList.contains('bar')).toBe(true);
+    expect(screen.getByText('with custom classes').classList.contains('foo')).toBe(
+      true,
+    );
+    expect(screen.getByText('with custom classes').classList.contains('bar')).toBe(
+      true,
+    );
   });
 });

--- a/test/testUtils/renderWithTestWrapper.tsx
+++ b/test/testUtils/renderWithTestWrapper.tsx
@@ -2,18 +2,11 @@ import React, { PropsWithChildren } from 'react';
 import { RenderResult, render as rtlRender } from '@testing-library/react';
 import userEvent, { UserEvent } from '@testing-library/user-event';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const render = (ui: React.ReactElement, { locale = 'en', ...options } = {}): RenderResult => {
-  const TestWrapper = ({ children }: PropsWithChildren) => {
-    return <main>{children}</main>;
-  };
-
-  return rtlRender(ui, { wrapper: TestWrapper, ...options });
-};
-
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const render2 = (ui: React.ReactElement, { locale = 'en', ...options } = {}): RenderResult & {user: UserEvent} => {
+const render = (
+  ui: React.ReactElement,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  { locale = 'en', ...options } = {},
+): RenderResult & { user: UserEvent } => {
   const TestWrapper = ({ children }: PropsWithChildren) => {
     return <main>{children}</main>;
   };
@@ -22,7 +15,7 @@ const render2 = (ui: React.ReactElement, { locale = 'en', ...options } = {}): Re
     user: userEvent.setup(),
     ...rtlRender(ui, { wrapper: TestWrapper, ...options }),
   };
-  
+
   return renderResult;
 };
 
@@ -30,4 +23,4 @@ const render2 = (ui: React.ReactElement, { locale = 'en', ...options } = {}): Re
 export * from '@testing-library/react';
 
 // override render method
-export { render, render2 };
+export { render };


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
- Removed the old test `render` function
- Updated the tests to use `userEvent`
- Removed the unused `prop-types` package

## Checklist

 - [x] Link to issue this PR refers to (if applicable): n/a
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
