### PR TITLE
Change `prepare` script to `prepack`

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "start": "vite",
     "build": "tsc && vite build",
-    "prepare": "yarn run build",
+    "prepack": "yarn run build",
     "test": "jest",
     "lint": "eslint --ext=.ts --ext=.tsx src/",
     "link-local": "yarn link && cd node_modules/react && yarn link && cd ../react-dom && yarn link",


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
This fix resolves the issue that `yarn build` runs every time `yarn install` runs.

## Checklist

 - [x] Link to issue this PR refers to (if applicable): n/a
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
