### PR TITLE
Change Error to Not Available for the gc status

### DIFF
--- a/src/components/Layout/Navigation.tsx
+++ b/src/components/Layout/Navigation.tsx
@@ -75,7 +75,7 @@ function Navigation({
       case ConnectionStatus.ERROR:
         classes = 'bg-red-700 text-white';
         icon = <WarningOutlined />;
-        label = 'Error';
+        label = 'Not available';
         break;
       case ConnectionStatus.PENDING:
         classes = 'bg-neutral-700 text-white';


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

It will error out by default if grand central is not started, so "Error" is a bit of a strong word.


## Checklist

 - [ ] Link to issue this PR refers to (if applicable): 
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
